### PR TITLE
Fix node.nextSibling.querySelectorAll is not a function

### DIFF
--- a/build/post-process.js
+++ b/build/post-process.js
@@ -120,7 +120,7 @@ function buildTableOfContents(dom, filePath) {
             return;
         }
 
-        node.nextSibling.querySelectorAll('dt').forEach(apiNode => {
+        node.nextElementSibling.querySelectorAll('dt').forEach(apiNode => {
             const code = apiNode.querySelector('code');
             if (!code || apiNode.closest('dd')) {
                 // ignore nested entries


### PR DESCRIPTION
The docs built by this repo are better than the ones I have in the MDN docsets maintained by me (I used to obtain the docs using `httrack`), so I'm currently working on using docs generated by your script in all the MDN docsets.

While generating the docs for the whole of MDN /en-us/, I ran into this error:

```
node.nextSibling.querySelectorAll is not a function
```

I've fixed it with the changes in this pull request.